### PR TITLE
Fix for Restart enable/disable in Debug menu dropdown

### DIFF
--- a/GUI/ARMSimForm.cs
+++ b/GUI/ARMSimForm.cs
@@ -1202,7 +1202,7 @@ namespace ARMSim.GUI
             (tdd.DropDownItems[0] as ToolStripMenuItem).Enabled = simulatorReady;//Run
             (tdd.DropDownItems[2] as ToolStripMenuItem).Enabled = simulatorReady;//Step-Into
             (tdd.DropDownItems[3] as ToolStripMenuItem).Enabled = simulatorReady;//Step-Over
-            (tdd.DropDownItems[5] as ToolStripMenuItem).Enabled = simulatorReady;//Restart
+            (tdd.DropDownItems[5] as ToolStripMenuItem).Enabled = mSimulationStopped;//Restart
             (tdd.DropDownItems[6] as ToolStripMenuItem).Enabled = mJM.ValidLoadedProgram;//Stop
             (tdd.DropDownItems[8] as ToolStripMenuItem).Enabled = simulatorReady;//Clear All Breakpoints
         }//debugToolStripMenuItem_DropDownOpening


### PR DESCRIPTION
The behavior for enabling and disabling the restart selection in the Debug menu dropdown was different than the restart button in the toolbar.  The toolbar uses the mSimulationStopped variable.  The dropdown menu used the simulatorReady variable.  The toolbar seemed to exhibit the correct behavior, so the dropdown menu was changed to match the toolbar.